### PR TITLE
Fix dangling slash in the code that was preventing the script to run

### DIFF
--- a/news_gatherer.py
+++ b/news_gatherer.py
@@ -81,7 +81,7 @@ def xml_to_json_payload_sender():
               pub_date = pub_date.replace(tzinfo=timezone.utc)
             
             if pub_date > time_threshold:
-\              news_items.append(f"• [{title.strip()}]({link.strip()})")
+              news_items.append(f"• [{title.strip()}]({link.strip()})")
           except Exception as e:
             continue
 


### PR DESCRIPTION
A simple slash that was dangling on the code was left there by mistake and was preventing the code to work as expected. Now the slash has been removed and the script is working as expected.