### PR TITLE
refactor: reorganize feeds directory structure and standardize .env path resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# ENVIRONMENT CONFIGURATION EXAMPLE
+# Copy this file to '.env' and populate with real credentials before running.
+# DO NOT commit the actual '.env' file to version control.
+
+# Discord Feeds
+NEWS_GATHERER_WEBHOOK="https://discordapp.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN"
+CVE_GATHERER_WEBHOOK="https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN"
+
+# IoC Gathering
+TWEETFEED_WEBHOOK="https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN"
+
+# IP Ban workers
+FAIL2BAN_WEBHOOK="https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN"
+ABUSE_IPDB_API_KEY="YOUR-ABUSEIPDB-API-KEY"

--- a/IoC_gathering/tweetfeed_fetcher.py
+++ b/IoC_gathering/tweetfeed_fetcher.py
@@ -22,7 +22,7 @@ STATE_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "last_seen
 # Load ENV variables from an .env file
 def load_env(file_path=None):
   if file_path is None:
-    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
+    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../.env")
 
   try:
     with open(file_path) as f:

--- a/discord_feeds/cve_gatherer.py
+++ b/discord_feeds/cve_gatherer.py
@@ -13,7 +13,7 @@ import os
 
 def load_env(file_path=None):
   if file_path is None:
-    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
+    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../.env")
     with open(file_path) as f:
       for line in f:
         if line.strip() and not line.startswith("#"):

--- a/discord_feeds/news_gatherer.py
+++ b/discord_feeds/news_gatherer.py
@@ -18,7 +18,7 @@ from email.utils import parsedate_to_datetime
 # Function to get .env variables
 def load_env(file_path=None):
   if file_path is None:
-    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
+    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../.env")
     try:
       with open(file_path) as f:
         for line in f:

--- a/ip_ban_worker/abuseIPDB/abuseipdb_report.sh
+++ b/ip_ban_worker/abuseIPDB/abuseipdb_report.sh
@@ -6,7 +6,7 @@
 dir_name=$(dirname "$0")
 
 # Get the API key from .env file and check if it has been properly set
-ABUSE_IPDB_API_KEY=$(grep -E '^ABUSE_IPDB_API_KEY' "$dir_name/../.env" | cut -d '=' -f 2 | tr -d '"' | tr -d "'")
+ABUSE_IPDB_API_KEY=$(grep -E '^ABUSE_IPDB_API_KEY' "$dir_name/../../.env" | cut -d '=' -f 2 | tr -d '"' | tr -d "'")
 
 if [ -z "$ABUSE_IPDB_API_KEY" ]; then
   echo 'Error: AbuseIPDB API Key not found in .env file.'

--- a/ip_ban_worker/ip_ban_monitor.sh
+++ b/ip_ban_worker/ip_ban_monitor.sh
@@ -11,7 +11,7 @@ EMBED_COLOR='15158332'
 dir_name=$(dirname "$0")
 
 # Get the webhook URL from an .env file without sourcing it 
-WEBHOOK=$(grep -E '^FAIL2BAN_WEBHOOK=' "$dir_name/.env" | cut -d '=' -f 2 | tr -d '"' | tr -d "'")
+WEBHOOK=$(grep -E '^FAIL2BAN_WEBHOOK=' "$dir_name/../.env" | cut -d '=' -f 2 | tr -d '"' | tr -d "'")
 
 # Check if webhook is present otherwise exit 
 if [ -z "$WEBHOOK" ]; then


### PR DESCRIPTION
## Summary of Changes

### 📁 Directory Reorganization
- Consolidated feed workers into `discord_feeds/`:
  - Moved `cve_worker/cve_gatherer.py` to `discord_feeds/cve_gatherer.py`
  - Moved `news_worker/news_gatherer.py` to `discord_feeds/news_gatherer.py`
- Removed obsolete `cve_worker/` and `news_worker/` directories.

### ⚙️ Environment Configuration
- Standardized relative `.env` path resolution across all sub-modules to target root `.env`:
  - `IoC_gathering/tweetfeed_fetcher.py`
  - `ip_ban_worker/ip_ban_monitor.sh`
  - `ip_ban_worker/abuseIPDB/abuseipdb_report.sh`
  - `discord_feeds/cve_gatherer.py`
  - `discord_feeds/news_gatherer.py`
- Added `.env.example` template at root directory detailing required webhooks & API keys.